### PR TITLE
Change the default icon ID to `32512` to be in line with the Windows default.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -373,7 +373,7 @@ impl WindowsResource {
     /// Equivalent to `set_icon_with_id(path, "32512")`.
     ///
     /// Windows uses `32512` as the default icon ID. See
-    /// [here](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona)
+    /// [here](https://learn.microsoft.com/en-us/windows/win32/menurc/about-icons#icon-types)
     /// for Windows docs demonstrating this.
     pub fn set_icon<'a>(&mut self, path: &'a str) -> &mut Self {
         const DEFAULT_APPLICATION_ICON_ID: &str = "32512";

--- a/lib.rs
+++ b/lib.rs
@@ -365,14 +365,18 @@ impl WindowsResource {
         self
     }
 
-    /// Add an icon with nameID `1`.
+    /// Add an icon with nameID `32512`.
     ///
-    /// This icon need to be in `ico` format. The filename can be absolute
+    /// This icon needs to be in `ico` format. The filename can be absolute
     /// or relative to the projects root.
     ///
-    /// Equivalent to `set_icon_with_id(path, "1")`.
+    /// Equivalent to `set_icon_with_id(path, "32512")`.
+    ///
+    /// Windows uses `32512` as the default icon ID. See
+    /// [here](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona)
+    /// for Windows docs demonstrating this.
     pub fn set_icon<'a>(&mut self, path: &'a str) -> &mut Self {
-        self.set_icon_with_id(path, "1")
+        self.set_icon_with_id(path, "32512")
     }
 
     /// Add an icon with the specified name ID.

--- a/lib.rs
+++ b/lib.rs
@@ -376,7 +376,9 @@ impl WindowsResource {
     /// [here](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona)
     /// for Windows docs demonstrating this.
     pub fn set_icon<'a>(&mut self, path: &'a str) -> &mut Self {
-        self.set_icon_with_id(path, "32512")
+        const DEFAULT_APPLICATION_ICON_ID: &str = "32512";
+
+        self.set_icon_with_id(path, DEFAULT_APPLICATION_ICON_ID)
     }
 
     /// Add an icon with the specified name ID.


### PR DESCRIPTION
I originally submitted a PR for this to the `winres` repo (https://github.com/mxre/winres/pull/39), but it was ignored. I'm hoping here I can finally get the change made.

**Relevant documentation:**
- Visual Studio test project demonstrating that VS uses `32512`: https://github.com/mxre/winres/issues/28#issuecomment-929585015
- Archived MSDN doc showing the `32512` value (original link in my old PR): https://web.archive.org/web/20220106224555/https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona#
- Newer MSDN doc showing the `32512` value: https://learn.microsoft.com/en-us/windows/win32/menurc/about-icons#icon-types

Closes #5.

