### PR TITLE
Make `toml` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ documentation= "https://docs.rs/winresource/*/winresource/"
 [lib]
 path = "lib.rs"
 
+[features]
+default = ["toml"]
+
 [dependencies]
-toml = "0.7"
+toml = { version = "0.7", optional = true }
 version_check = "0.9"
 
 [dev-dependencies]

--- a/lib.rs
+++ b/lib.rs
@@ -53,6 +53,7 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process;
 
+#[cfg(feature = "toml")]
 extern crate toml;
 
 /// Version info field names
@@ -175,6 +176,7 @@ impl WindowsResource {
 
         props.insert("FileDescription".to_string(), description);
 
+        #[cfg(feature = "toml")]
         parse_cargo_toml(&mut props).unwrap();
 
         let mut version = 0_u64;
@@ -813,6 +815,7 @@ fn get_sdk() -> io::Result<Vec<PathBuf>> {
     Ok(kits)
 }
 
+#[cfg(feature = "toml")]
 fn parse_cargo_toml(props: &mut HashMap<String, String>) -> io::Result<()> {
     let cargo = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
     let mut f = fs::File::open(cargo)?;


### PR DESCRIPTION
This PR makes reading properties from Cargo.toml optional. This change does not introduce any breaking change because the feature is enabled by default.

The motivation of this change is to reduce dependencies.

`toml` is enabled:

```
> cargo tree
winresource v0.1.16 (C:\Users\rhysd\Dev\winresource)
├── toml v0.7.6
│   ├── serde v1.0.185
│   ├── serde_spanned v0.6.3
│   │   └── serde v1.0.185
│   ├── toml_datetime v0.6.3
│   │   └── serde v1.0.185
│   └── toml_edit v0.19.14
│       ├── indexmap v2.0.0
│       │   ├── equivalent v1.0.1
│       │   └── hashbrown v0.14.0
│       ├── serde v1.0.185
│       ├── serde_spanned v0.6.3 (*)
│       ├── toml_datetime v0.6.3 (*)
│       └── winnow v0.5.14
└── version_check v0.9.4
```

`toml` is disabled:

```
> cargo tree --no-default-features
winresource v0.1.16 (C:\Users\rhysd\Dev\winresource)
└── version_check v0.9.4
```

When all properties are set in build.rs, the `toml` crate dependency is a pure overhead. Since the crate depends on serde, which is a large crate, it makes builds slower. This PR aims to opt-out the overhead.