### PR TITLE
[MSVC] Use RC_PATH for rc if specified, or fallback to llvm-rc (on Unix) or rc.exe (on Windows)

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -13,11 +13,8 @@ LegalCopyright = "Copyright © 2016-2017"
 # this FileDescription overrides package.description
 FileDescription = "Example for \"winres\""
 
-[dependencies]
-winapi = { version = "0.3", features = [ "winuser" ] }
-
 # always use target build-dependencies for winres so that
 # it won't get pulled for non-windows OSs (saves them resources)
 [build-dependencies]
 # winres project
-winres = { path = ".." }
+winresource = { path = ".." }

--- a/example/build.rs
+++ b/example/build.rs
@@ -1,32 +1,11 @@
 extern crate winresource;
 
 fn main() {
-    // only run if target os is windows
-    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() != "windows" {
-        return;
-    }
-
-    // only build the resource for release builds
-    // as calling rc.exe might be slow
-    if std::env::var("PROFILE").unwrap() == "release" {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
         let mut res = winresource::WindowsResource::new();
-        if cfg!(unix) {
-            // paths for X64 on archlinux
-            res.set_toolkit_path("/usr/x86_64-w64-mingw32/bin");
-            // ar tool for mingw in toolkit path
-            res.set_ar_path("ar");
-            // windres tool
-            res.set_windres_path("/usr/bin/x86_64-w64-mingw32-windres");
-        }
-
         res.set_icon("icon.ico")
-            // can't use winapi crate constants for cross compiling
-            // MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US )
             .set_language(0x0409)
             .set_manifest_file("manifest.xml");
-        if let Err(e) = res.compile() {
-            eprintln!("{}", e);
-            std::process::exit(1);
-        }
+        res.compile().unwrap();
     }
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,17 +1,6 @@
-extern crate winapi;
-
-use std::ffi::CString;
-use winapi::um::winuser::{MessageBoxA, MB_ICONINFORMATION, MB_OK};
+use std::io::stdin;
 
 fn main() {
-    let lp_text = CString::new("Hello, world!").unwrap();
-    let lp_caption = CString::new("MessageBox Example").unwrap();
-    unsafe {
-        MessageBoxA(
-            std::ptr::null_mut(),
-            lp_text.as_ptr(),
-            lp_caption.as_ptr(),
-            MB_OK | MB_ICONINFORMATION,
-        );
-    }
+    println!("Hello winresource!");
+    stdin().lines().next();
 }

--- a/lib.rs
+++ b/lib.rs
@@ -697,10 +697,10 @@ impl WindowsResource {
     }
 
     fn compile_with_toolkit_msvc<'a>(&self, input: &'a str, output_dir: &'a str) -> io::Result<()> {
-        let rc_exe = if let Ok(rc_path) = std::env::var("RC_PATH") {
-            PathBuf::from_str(&rc_path).unwrap()
+        let rc_exe = if let Some(rc_path) = std::env::var_os("RC_PATH") {
+            PathBuf::from(rc_path)
         } else if cfg!(unix) {
-            PathBuf::from_str("llvm-rc").unwrap()
+            PathBuf::from("llvm-rc")
         } else {
             let rc_exe = PathBuf::from(&self.toolkit_path).join("rc.exe");
             if !rc_exe.exists() {


### PR DESCRIPTION
Fixes example
Fixes #15 

Probably there are needed more changes to supress this:
```
warning: winres-example@0.1.3: unknown Windows target used for cross-compilation; invoking unprefixed windres
```