### PR TITLE
Add support for `*-pc-windows-gnullvm` targets

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -227,6 +227,10 @@ impl WindowsResource {
                 // MinGW supports ARM64 only with an LLVM-based toolchain
                 // (x86 users might also be using LLVM, but we can't tell that from the Rust target...)
                 "aarch64-pc-windows-gnu" => "llvm-",
+                // *-gnullvm targets by definition use LLVM-based toolchains
+                "x86_64-pc-windows-gnullvm"
+                | "i686-pc-windows-gnullvm"
+                | "aarch64-pc-windows-gnullvm" => "llvm-",
                 // fail safe
                 _ => {
                     println!(


### PR DESCRIPTION
These are tier 2 LLVM-based toolchains, so the LLVM prefix for windres should be used. I've tested these changes by compiling a "hello world" executable for the target in a Docker container and everything worked well, as far as I could see.