### PR TITLE
Improve xwin compatibility on MacOS host

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -695,13 +695,6 @@ impl WindowsResource {
         }
     }
 
-    #[cfg(not(windows))]
-    #[inline(always)]
-    fn compile_with_toolkit_msvc<'a>(&self, input: &'a str, output_dir: &'a str) -> io::Result<()> {
-        self.compile_with_toolkit_gnu(input, output_dir)
-    }
-
-    #[cfg(windows)]
     fn compile_with_toolkit_msvc<'a>(&self, input: &'a str, output_dir: &'a str) -> io::Result<()> {
         let rc_exe = if let Some(rc_path) = std::env::var_os("RC_PATH") {
             PathBuf::from(rc_path)

--- a/lib.rs
+++ b/lib.rs
@@ -727,6 +727,7 @@ impl WindowsResource {
         }
         let status = command
             .arg(format!("/fo{}", output.display()))
+            .arg("--")
             .arg(format!("{}", input.display()))
             .output()?;
 


### PR DESCRIPTION
This fixes some issues I've experienced on getting winresource to work under xwin cross compilation compiling with the msvc environment.