### PR TITLE
Do not run the set_language doctest

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -321,7 +321,7 @@ impl WindowsResource {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no_run
     /// extern crate winapi;
     /// extern crate winresource;
     /// # use std::io;


### PR DESCRIPTION
This test fails because the CARGO_CFG_TARGET_OS environment variable is not set during doctests