### PR TITLE
Better support for llvm-rc

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -725,11 +725,18 @@ impl WindowsResource {
             command.arg(format!("/I{}", root.join("um").display()));
             command.arg(format!("/I{}", root.join("shared").display()));
         }
-        let status = command
-            .arg(format!("/fo{}", output.display()))
-            .arg("--")
-            .arg(format!("{}", input.display()))
-            .output()?;
+
+        command.arg(format!("/fo{}", output.display()));
+
+        if cfg!(unix) {
+            // Fix for https://github.com/llvm/llvm-project/issues/63426
+            command.args(["/C", "65001"]);
+
+            // Ensure paths starting with "/Users" on macOS are not interpreted as a /U option
+            command.arg("--");
+        }
+
+        let status = command.arg(format!("{}", input.display())).output()?;
 
         println!(
             "RC Output:\n{}\n------",


### PR DESCRIPTION
Adds the /C 65001 option to support UTF-8 for llvm-rc

And fixes issue #28 by only adding `--` on unix systems