### PR TITLE
Use cargo:rustc-link-lib=static=resource

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -767,7 +767,7 @@ impl WindowsResource {
         }
 
         println!("cargo:rustc-link-search=native={}", output_dir);
-        println!("cargo:rustc-link-lib=dylib=resource");
+        println!("cargo:rustc-link-lib=static=resource");
         Ok(())
     }
 }


### PR DESCRIPTION
When linking, tell cargo to treat the resource as a static lib.

Fixes #36 