### PR TITLE
Fix MSVC resource linking: link compiled resources via .res linker arg (avoid resource.lib)

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -59,7 +59,7 @@ extern crate toml;
 /// Version info field names
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum VersionInfo {
-    /// The version value consists of four 16 bit words, e.g.,
+    /// The version value consists of four 16 bit words, e.g.,&
     /// `MAJOR << 48 | MINOR << 32 | PATCH << 16 | RELEASE`
     FILEVERSION,
     /// The version value consists of four 16 bit words, e.g.,
@@ -719,7 +719,7 @@ impl WindowsResource {
         };
 
         println!("Selected RC path: '{}'", rc_exe.display());
-        let output = PathBuf::from(output_dir).join("resource.lib");
+        let output = PathBuf::from(output_dir).join("resource.res");
         let input = PathBuf::from(input);
         let mut command = process::Command::new(&rc_exe);
         let command = command.arg(format!("/I{}", env::var("CARGO_MANIFEST_DIR").unwrap()));
@@ -754,9 +754,8 @@ impl WindowsResource {
         if !status.status.success() {
             return Err(io::Error::other("Could not compile resource file"));
         }
-
         println!("cargo:rustc-link-search=native={}", output_dir);
-        println!("cargo:rustc-link-lib=dylib=resource");
+        println!("cargo:rustc-link-arg={}", output.display());
         Ok(())
     }
 }

--- a/lib.rs
+++ b/lib.rs
@@ -59,7 +59,7 @@ extern crate toml;
 /// Version info field names
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum VersionInfo {
-    /// The version value consists of four 16 bit words, e.g.,&
+    /// The version value consists of four 16 bit words, e.g.,
     /// `MAJOR << 48 | MINOR << 32 | PATCH << 16 | RELEASE`
     FILEVERSION,
     /// The version value consists of four 16 bit words, e.g.,

--- a/lib.rs
+++ b/lib.rs
@@ -754,8 +754,9 @@ impl WindowsResource {
         if !status.status.success() {
             return Err(io::Error::other("Could not compile resource file"));
         }
-        println!("cargo:rustc-link-search=native={}", output_dir);
+
         println!("cargo:rustc-link-arg={}", output.display());
+
         Ok(())
     }
 }


### PR DESCRIPTION
First of all, thanks a lot for your work and a nice crate!

This PR fixes the **Unsupported archive identifier** error while building an `msvc` target:
```
error: failed to add native library <project_root>\x86_64-pc-windows-msvc\debug\build\<package_name>-cc8df11cd2e2bce3\out\resource.lib: Unsupported archive identifier
```
Should also close #40 "Failed to add native library after updating to 0.1.25"

#### Root cause
The `rustc` is trying to treat `...\out\resource.lib` as a _native library archive_, but the file that `rc.exe` produces with `/fo...resource.lib` is **not an MSVC .lib archive**. Instead, it is a compiled resource blob, typically a .res COFF resource file. When the rustc/linker pipeline tries to load it “as a library”, it fails with: "Unsupported archive identifier".

#### Fix 
1. compile `resource.rc` → `resource.res`
2. pass `resource.res` to the linker via cargo:rustc-link-**arg**=...

Note the **-arg** instead of **-lib** in linker option.