### PR TITLE
Use `zig rc` compiler when building with zig as linker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,18 @@ jobs:
         run: |
           docker run -v .:/Users/winresource -w /Users/winresource/example xwin cargo xwin build --target x86_64-pc-windows-msvc
 
+  zig:
+    name: Build example on Linux using zig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: mlugg/setup-zig@v2
+      - name: Install x86_64-pc-windows-gnu Rust target
+        run: rustup target add x86_64-pc-windows-gnu
+      - name: Install cargo-zigbuild
+        run: |
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall -y cargo-zigbuild
+      - name: Build example
+        run: cargo zigbuild --manifest-path example/Cargo.toml --target x86_64-pc-windows-gnu

--- a/lib.rs
+++ b/lib.rs
@@ -690,6 +690,9 @@ impl WindowsResource {
             rc.to_str().unwrap().to_string()
         };
 
+        if is_using_zig_toolchain() {
+            return self.compile_with_toolkit_msvc(rc.as_str(), &self.output_directory);
+        }
         let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
         match target_env.as_str() {
             "gnu" => self.compile_with_toolkit_gnu(rc.as_str(), &self.output_directory),
@@ -703,6 +706,8 @@ impl WindowsResource {
     fn compile_with_toolkit_msvc(&self, input: &str, output_dir: &str) -> io::Result<()> {
         let rc_exe = if let Some(rc_path) = std::env::var_os("RC_PATH") {
             PathBuf::from(rc_path)
+        } else if is_using_zig_toolchain() {
+            PathBuf::from("zig")
         } else if cfg!(unix) {
             PathBuf::from("llvm-rc")
         } else {
@@ -722,7 +727,10 @@ impl WindowsResource {
         let output = PathBuf::from(output_dir).join("resource.res");
         let input = PathBuf::from(input);
         let mut command = process::Command::new(&rc_exe);
-        let command = command.arg(format!("/I{}", env::var("CARGO_MANIFEST_DIR").unwrap()));
+        if is_using_zig_toolchain() {
+            command.arg("rc");
+        }
+        command.arg(format!("/I{}", env::var("CARGO_MANIFEST_DIR").unwrap()));
 
         if self.add_toolkit_include {
             let root = win_sdk_include_root(&rc_exe);
@@ -759,6 +767,10 @@ impl WindowsResource {
 
         Ok(())
     }
+}
+
+fn is_using_zig_toolchain() -> bool {
+    env::var("RUSTC_LINKER").unwrap_or_default().contains("zig")
 }
 
 /// Find a Windows SDK


### PR DESCRIPTION
@BenjaminRi thanks for keeping the "winres" crate up-to-date in this fork.

This rough pr adds support for building Windows resources using Zig as a cross-compilation toolchain. This can easily be done with [cargo-zigbuild](https://github.com/rust-cross/cargo-zigbuild):

```sh
cargo zigbuild --target x86_64-pc-windows-gnu
```

Zig has included a Windows resource compiler for some time now (see: https://www.ryanliptak.com/blog/zig-is-a-windows-resource-compiler/), which is handy because it removes the need to install a full MinGW64 toolchain locally. The `zig rc` command is intended to be fully compatible with `rc.exe`, so I extended the `compile_with_toolkit_msvc()` function to support it.

The linking is still done against the GNU MinGW C runtime, which makes the current structure a bit confusing maybe. It might make sense to split this functionality into a separate function for clarity.

Looking forward to feedback :^)