### PR TITLE
Update toml dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 default = ["toml"]
 
 [dependencies]
-toml = { version = "0.9", optional = true, default-features = false, features = [
+toml = { version = "1.0", optional = true, default-features = false, features = [
     "std",
     "parse",
     "serde",


### PR DESCRIPTION
It looks like this was just a "milestone" release, with no significant (breaking) changes:

https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#100---2026-02-11

However, this would allow us (over at Ruffle) to update the `toml` crate family without duplication.